### PR TITLE
Add PR-Agent setup instructions

### DIFF
--- a/.github/workflows/pr-agent.yaml
+++ b/.github/workflows/pr-agent.yaml
@@ -1,0 +1,24 @@
+name: pr-agent
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  pr_agent:
+    runs-on: ubuntu-latest
+    name: Run PR Agent
+    if: ${{ github.event.sender.type != 'Bot' }}
+    steps:
+      - id: pr-agent
+        uses: Codium-ai/pr-agent@main
+        env:
+          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_REVIEWER.EXTRA_INSTRUCTIONS: "Please use Japanese in descriptions."

--- a/README.md
+++ b/README.md
@@ -36,3 +36,19 @@ export default {
 - [Vitest で React のテストを書いてみる](https://zenn.dev/collabostyle/articles/15883dcd38c9ff)
 
 - [Vite は使ってないけど Jest を Vitest に移行する](https://zenn.dev/sa2knight/articles/migrating_vitest_from_jest)
+
+## PR-Agent
+
+- ref
+  - [PR-Agent を使って Pull Request を AI レビューしてみた。（日本語対応もしてみた）](https://tech.layerx.co.jp/entry/2023/09/01/102612)
+
+```
+// github
+open target repository
+select Setting and open "Secrets and variables"
+select "Actions"
+add "OPENAI_KEY" in Repository Secrets
+
+// your repository
+create .github/workflows/pr-agent.yaml
+```


### PR DESCRIPTION
This pull request adds setup instructions for PR-Agent, a tool that allows for AI review of pull requests. The instructions include adding the OPENAI_KEY to the repository secrets and creating a pr-agent.yaml file in the .github/workflows directory. These instructions will enable the use of PR-Agent for AI review of pull requests.