### PR TITLE
Add path filters for CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,8 @@ name: "CI | Function Tests"
 
 on:
   push:
+    paths:
+      - "src/**"
     branches: [develop]
   pull_request:
     branches: [develop]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,11 +2,15 @@ name: "CI | Function Tests"
 
 on:
   push:
+    branches:
+      - develop
     paths:
       - "src/**"
-    branches: [develop]
   pull_request:
-    branches: [develop]
+    branches:
+      - develop
+    paths:
+      - "src/**"
 
 permissions:
   pull-requests: write

--- a/.github/workflows/pr-agent.yaml
+++ b/.github/workflows/pr-agent.yaml
@@ -2,13 +2,13 @@ name: pr-agent
 
 on:
   pull_request:
-    branches: [develop]
+    branches:
+      - develop
+    paths:
+      - "src/**"
     types: [opened, reopened, synchronize]
   issue_comment:
     types: [created, edited]
-  push:
-    paths:
-      - "src/**"
 
 permissions:
   pull-requests: write

--- a/.github/workflows/storybook-tests.yaml
+++ b/.github/workflows/storybook-tests.yaml
@@ -2,11 +2,15 @@ name: "CI | Storybook Interaction/assert Tests"
 
 on:
   push:
+    branches:
+      - develop
     paths:
       - "src/**"
-    branches: [develop]
   pull_request:
-    branches: [develop]
+    branches:
+      - develop
+    paths:
+      - "src/**"
 
 jobs:
   test:

--- a/.github/workflows/storybook-tests.yaml
+++ b/.github/workflows/storybook-tests.yaml
@@ -2,6 +2,8 @@ name: "CI | Storybook Interaction/assert Tests"
 
 on:
   push:
+    paths:
+      - "src/**"
     branches: [develop]
   pull_request:
     branches: [develop]


### PR DESCRIPTION
This pull request adds path filters for the CI workflows to only trigger when changes are made to the "src" directory. This improves the efficiency of the CI process by reducing unnecessary builds and tests.