### PR TITLE
Update CI workflow to use Jest Annotations & Coverage action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,12 +52,19 @@ jobs:
           cache: npm
 
       - run: npm ci
-      - run: npm run vitest:coverage
-      - name: Vitest Coverage Report
-        uses: davelosert/vitest-coverage-report-action@v2.2.0
+      - name: Jest Annotations & Coverage
+        uses: mattallty/jest-github-action@v1.0.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          json-summary-path: "./coverage/vitest/coverage-summary.json"
-          json-final-path: "./coverage/vitest/coverage-final.json"
+          test-command: "npm run vitest:coverage"
+
+      # - run: npm run vitest:coverage
+      # - name: Vitest Coverage Report
+      #   uses: davelosert/vitest-coverage-report-action@v2.2.0
+      #   with:
+      #     json-summary-path: "./coverage/vitest/coverage-summary.json"
+      #     json-final-path: "./coverage/vitest/coverage-final.json"
 
   build:
     runs-on: ubuntu-latest

--- a/src/ui/CiTest.tsx
+++ b/src/ui/CiTest.tsx
@@ -1,0 +1,4 @@
+import { type ReactElement } from 'react';
+
+const CiTest = (): ReactElement => <div>CI Test</div>;
+export default CiTest;


### PR DESCRIPTION
This pull request updates the CI workflow to use the Jest Annotations & Coverage action. It replaces the previous Vitest Coverage Report action with the new action provided by mattallty/jest-github-action. Additionally, a new component called CiTest has been added to the src/ui directory.