### PR TITLE
Add fetch-depth option to checkout step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
     paths:
+      - '.github/**'
       - "src/**"
       - "!src/**/stories/**"
       - "!src/**/assets/**"
@@ -13,6 +14,7 @@ on:
     branches:
       - develop
     paths:
+      - '.github/**'
       - "src/**"
       - "!src/**/stories/**"
       - "!src/**/assets/**"
@@ -32,6 +34,8 @@ jobs:
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: " Use Node.js 20.10.0"
         uses: actions/setup-node@v4
@@ -47,8 +51,8 @@ jobs:
           key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ hashFiles('${{ env.WORKING_DIR }}/package-lock.json') }}
 
       - name: npm-install
+        run: npm ci
         if: ${{ steps.node_modules_cache_id.outputs.cache-hit != 'true' }}
-        run: npm i
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
       #   run: npm ci
       #   if: ${{ steps.node_modules_cache_id.outputs.cache-hit != 'true' }}
 
-  lint:
+  ci:
     runs-on: ubuntu-latest
     # needs: setup
     steps:
@@ -73,49 +73,27 @@ jobs:
       #     path: ${{ env.WORKING_DIR }}/node_modules
       #     key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ hashFiles('${{ env.WORKING_DIR }}/package-lock.json') }}
 
+      - name: npm Install
+        run: npm ci
       - name: es-lint
-        run: npm ci && npm run lint
-
-  test:
-    runs-on: ubuntu-latest
-    # needs: setup
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v4
-
-      - name: " Use Node.js 20.10.0"
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20.10.0
-          cache: npm
-
-      # - name: restore-node_modules-cache
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: ${{ env.WORKING_DIR }}/node_modules
-      #     key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ hashFiles('${{ env.WORKING_DIR }}/package-lock.json') }}
-
+        run: npm run lint
       - name: vitest-coverage
-        run: npm ci && npm run vitest:coverage
+        run: npm run vitest:coverage
+      - name: build
+        run: npm run build
 
-      - name: Vitest Coverage Report
-        uses: davelosert/vitest-coverage-report-action@v2.2.0
-        with:
-          json-summary-path: "./coverage/vitest/coverage-summary.json"
-          json-final-path: "./coverage/vitest/coverage-final.json"
+  # test:
+  #   runs-on: ubuntu-latest
+  #   # needs: setup
+  #   steps:
+  #     - name: "Checkout"
+  #       uses: actions/checkout@v4
 
-  build:
-    runs-on: ubuntu-latest
-    # needs: test
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v4
-
-      - name: " Use Node.js 20.10.0"
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20.10.0
-          cache: npm
+  #     - name: " Use Node.js 20.10.0"
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: 20.10.0
+  #         cache: npm
 
       # - name: restore-node_modules-cache
       #   uses: actions/cache@v4
@@ -123,5 +101,33 @@ jobs:
       #     path: ${{ env.WORKING_DIR }}/node_modules
       #     key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ hashFiles('${{ env.WORKING_DIR }}/package-lock.json') }}
 
-      - name: build
-        run: npm ci && npm run build
+      # - name: vitest-coverage
+      #   run: npm ci && npm run vitest:coverage
+
+      # - name: Vitest Coverage Report
+      #   uses: davelosert/vitest-coverage-report-action@v2.2.0
+      #   with:
+      #     json-summary-path: "./coverage/vitest/coverage-summary.json"
+      #     json-final-path: "./coverage/vitest/coverage-final.json"
+
+  # build:
+  #   runs-on: ubuntu-latest
+  #   # needs: test
+  #   steps:
+  #     - name: "Checkout"
+  #       uses: actions/checkout@v4
+
+  #     - name: " Use Node.js 20.10.0"
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: 20.10.0
+  #         cache: npm
+
+      # - name: restore-node_modules-cache
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: ${{ env.WORKING_DIR }}/node_modules
+      #     key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ hashFiles('${{ env.WORKING_DIR }}/package-lock.json') }}
+
+      # - name: build
+      #   run: npm ci && npm run build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
       #     key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ hashFiles('${{ env.WORKING_DIR }}/package-lock.json') }}
 
       - name: es-lint
-        run: npm run lint
+        run: npm ci && npm run lint
 
   test:
     runs-on: ubuntu-latest
@@ -96,7 +96,7 @@ jobs:
       #     key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ hashFiles('${{ env.WORKING_DIR }}/package-lock.json') }}
 
       - name: vitest-coverage
-        run: npm run vitest:coverage
+        run: npm ci && npm run vitest:coverage
 
       - name: Vitest Coverage Report
         uses: davelosert/vitest-coverage-report-action@v2.2.0
@@ -124,4 +124,4 @@ jobs:
       #     key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ hashFiles('${{ env.WORKING_DIR }}/package-lock.json') }}
 
       - name: build
-        run: npm run build
+        run: npm ci && npm run build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,39 +24,39 @@ permissions:
   pull-requests: write
   contents: read
 
-env:
-  WORKING_DIR: '.'
-  CACHE_NAME: node_modules_cache
+# env:
+#   WORKING_DIR: '.'
+#   CACHE_NAME: node_modules_cache
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+  # setup:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: "Checkout"
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
 
-      - name: " Use Node.js 20.10.0"
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20.10.0
-          cache: npm
+  #     - name: " Use Node.js 20.10.0"
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: 20.10.0
+  #         cache: npm
 
-      - name: cache-node-modules
-        uses: actions/cache@v4
-        id: node_modules_cache_id
-        with:
-          path: ${{ env.WORKING_DIR }}/node_modules
-          key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ hashFiles('${{ env.WORKING_DIR }}/package-lock.json') }}
+      # - name: cache-node-modules
+      #   uses: actions/cache@v4
+      #   id: node_modules_cache_id
+      #   with:
+      #     path: ${{ env.WORKING_DIR }}/node_modules
+      #     key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ hashFiles('${{ env.WORKING_DIR }}/package-lock.json') }}
 
-      - name: npm-install
-        run: npm ci
-        if: ${{ steps.node_modules_cache_id.outputs.cache-hit != 'true' }}
+      # - name: npm-install
+      #   run: npm ci
+      #   if: ${{ steps.node_modules_cache_id.outputs.cache-hit != 'true' }}
 
   lint:
     runs-on: ubuntu-latest
-    needs: setup
+    # needs: setup
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
@@ -67,18 +67,18 @@ jobs:
           node-version: 20.10.0
           cache: npm
 
-      - name: restore-node_modules-cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.WORKING_DIR }}/node_modules
-          key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ hashFiles('${{ env.WORKING_DIR }}/package-lock.json') }}
+      # - name: restore-node_modules-cache
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: ${{ env.WORKING_DIR }}/node_modules
+      #     key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ hashFiles('${{ env.WORKING_DIR }}/package-lock.json') }}
 
       - name: es-lint
         run: npm run lint
 
   test:
     runs-on: ubuntu-latest
-    needs: setup
+    # needs: setup
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
@@ -89,11 +89,11 @@ jobs:
           node-version: 20.10.0
           cache: npm
 
-      - name: restore-node_modules-cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.WORKING_DIR }}/node_modules
-          key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ hashFiles('${{ env.WORKING_DIR }}/package-lock.json') }}
+      # - name: restore-node_modules-cache
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: ${{ env.WORKING_DIR }}/node_modules
+      #     key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ hashFiles('${{ env.WORKING_DIR }}/package-lock.json') }}
 
       - name: vitest-coverage
         run: npm run vitest:coverage
@@ -106,7 +106,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: test
+    # needs: test
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
@@ -117,11 +117,11 @@ jobs:
           node-version: 20.10.0
           cache: npm
 
-      - name: restore-node_modules-cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.WORKING_DIR }}/node_modules
-          key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ hashFiles('${{ env.WORKING_DIR }}/package-lock.json') }}
+      # - name: restore-node_modules-cache
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: ${{ env.WORKING_DIR }}/node_modules
+      #     key: ${{ runner.os }}-${{ env.CACHE_NAME }}-${{ hashFiles('${{ env.WORKING_DIR }}/package-lock.json') }}
 
       - name: build
         run: npm run build


### PR DESCRIPTION
This pull request adds the fetch-depth option to the checkout step in the CI workflow. This allows for a shallow clone of the repository, reducing the amount of data transferred during the checkout process.