### PR TITLE
Exclude unnecessary files from coverage report

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,3 +12,4 @@ public/
 .*lintrc.js
 **/stories/
 **/tests/
+**/*.gen.ts

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'json-summary', 'json'],
       reportsDirectory: './coverage/vitest',
+      // カバレッジレポートに表示しないファイルを指定
       exclude: [
         'postcss.config.js',
         'tailwind.config.js',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,7 +12,22 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'json-summary', 'json'],
       reportsDirectory: './coverage/vitest',
-      all: false, // これをtrueにすると全てのファイルがカバレッジレポートに表示される
+      exclude: [
+        'postcss.config.js',
+        'tailwind.config.js',
+        '.eslintrc.cjs',
+        '.storybook/',
+        'src/stories/',
+        'src/App.tsx',
+        'src/main.tsx',
+        'src/routeTree.gen.ts',
+        'src/components/',
+        'src/constants/',
+        'src/libs',
+        'src/routes/',
+        'src/ui/',
+      ],
+      // all: true, // これをtrueにすると全てのファイルがカバレッジレポートに表示される
     },
     // これを有効にしないとexpect関数でエラーする
     // ReferenceError: expect is not defined


### PR DESCRIPTION
This pull request excludes unnecessary files from the coverage report to improve the accuracy of the coverage analysis.